### PR TITLE
fix(main-menu-canvas): Planet animations bug fixed.

### DIFF
--- a/Assets/Game/States/Main/MainMenuState.cs
+++ b/Assets/Game/States/Main/MainMenuState.cs
@@ -90,6 +90,7 @@ namespace SpaceShooterProject.State
             mainMenuCanvas.OnNextPlanetButtonRequest -= mainMenuCanvas.PlanetUIController.NextPlanet;
             mainMenuCanvas.OnPreviousPlanetButtonRequest -= mainMenuCanvas.PlanetUIController.PreviousPlanet;
             mainMenuCanvas.PlanetUIController.UnSubscribeAllPlanetAnimationCompletionEvents();
+            mainMenuCanvas.PlanetUIController.CompleteAllPlanetAnimations();
 
             Debug.Log("MainMenuState OnExit");
         }

--- a/Assets/Game/UserInterface/MainMenu/PlanetUI.cs
+++ b/Assets/Game/UserInterface/MainMenu/PlanetUI.cs
@@ -15,11 +15,13 @@ public class PlanetUI : MonoBehaviour
 
     private PlanetUI previousPlanet;
     private PlanetUI nextPlanet;
+    private Tween moveTween;
+    private Tween scaleTween;
     private bool isActive;
 
     public void Move(RectTransform self, RectTransform target)
     {
-        self.DOMove(target.position, animationDuration)
+        moveTween = self.DOMove(target.position, animationDuration)
             .SetUpdate(UpdateType.Fixed)
             .SetEase(moveEase)
             .OnComplete(() =>
@@ -28,7 +30,7 @@ public class PlanetUI : MonoBehaviour
                     OnAnimationsCompleted();
             });
 
-        self.DOScale(target.localScale, animationDuration)
+        scaleTween = self.DOScale(target.localScale, animationDuration)
             .SetUpdate(UpdateType.Fixed)
             .SetEase(scaleEase)
             .OnComplete(() => OnAnimationsCompleted());
@@ -51,6 +53,12 @@ public class PlanetUI : MonoBehaviour
         transform.localScale = Vector3.one * activeScaleAmount;
     }
 
+    public void CompleteAllAnimations()
+    {
+        moveTween.Complete();
+        scaleTween.Complete();
+    }
+
     public RectTransform Transform => transform;
 
     public string Name => name;
@@ -60,5 +68,4 @@ public class PlanetUI : MonoBehaviour
         get => isActive;
         set => isActive = value;
     }
-
 }

--- a/Assets/Game/UserInterface/MainMenu/PlanetUIController.cs
+++ b/Assets/Game/UserInterface/MainMenu/PlanetUIController.cs
@@ -105,4 +105,10 @@ public class PlanetUIController : MonoBehaviour, IInitializable
             completedAnimationCounter = 0;
         }
     }
+
+    public void CompleteAllPlanetAnimations()
+    {
+        planets.ForEach(planet => { planet.CompleteAllAnimations(); });
+        allPlanetAnimationsCompleted = true;
+    }
 }


### PR DESCRIPTION
_MainMenuState -> OnExit() method is updated._

**Problem:** When user try to go to another menu from main menu while planet animation is running, "allAnimationsCompleted" variable did not update.
**Solution:** All animations are forced to complete on PlanetUIController and value of "allAnimationsCompleted" variable is changed to true on OnExit method of MainMenuState.



Co-Authored-By: Oktay Türkdağlı <61520877+oktayturkdagli@users.noreply.github.com>
Co-Authored-By: Mertcan Aşgün <masgun17@ku.edu.tr>